### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/v3-core.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # Uniswap V3
 
 [![Lint](https://github.com/Uniswap/uniswap-v3-core/actions/workflows/lint.yml/badge.svg)](https://github.com/Uniswap/uniswap-v3-core/actions/workflows/lint.yml)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/v3-core",
-  "description": "🦄 Core smart contracts of Uniswap V3",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "license": "BUSL-1.1",
   "publishConfig": {
     "access": "public"
   },
   "version": "1.0.1",
-  "homepage": "https://uniswap.org",
+  "homepage": "https://github.com/primeanetwork/v3-core#readme",
   "keywords": [
     "uniswap",
     "core",
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/uniswap-v3-core"
+    "url": "git+ssh://git@github.com/primeanetwork/v3-core.git"
   },
   "files": [
     "contracts/interfaces",
@@ -55,5 +55,8 @@
   "scripts": {
     "compile": "hardhat compile",
     "test": "hardhat test"
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/v3-core/issues"
   }
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/v3-core`. **No product code changes.**